### PR TITLE
Fix typos in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The *mvs-calculus* is a small experimental language, centered around the concept
 
 Unrestricted mutation of shared state is a source of many well-known problems.
 The predominant safe solutions are pure functional programming, which simply bans mutation.
-Mutable value semantics is a different approach that bans sharing instead of mutation, thereby supporting part-wise in-place mutationand local reasoning.
+Mutable value semantics is a different approach that bans sharing instead of mutation, thereby supporting part-wise in-place mutation and local reasoning.
 
 ## Installation
 
@@ -12,7 +12,7 @@ This project is written in [Swift](https://swift.org) and distributed in the for
 
 You will need to install LLVM 11.0.
 Use your favorite package manager (e.g., `port` on macOS or `apt` on Ubuntu) and make sure `llvm-config` is in your PATH.
-Then, create a `pkgconfig` file for your specific installation
+Then, create a `pkgconfig` file for your specific installation.
 The maintainers of [LLVMSwift](https://github.com/llvm-swift/LLVMSwift) were kind enough to provide a script:
 
 ```bash
@@ -27,7 +27,7 @@ swift .build/checkouts/LLVMSwift/utils/make-pkgconfig.swift
 > apt-get install libc++abi-dev
 > ```
 
-Once LLVM is installed and configure, compile the compiler and the runtime library with the following commands:
+Once LLVM is installed and configured, compile the compiler and the runtime library with the following commands:
 
 ```bash
 swift build -c release
@@ -35,7 +35,7 @@ c++ -std=c++14 -c Runtime/runtime.cc -o .build/release/runtime.o
 ```
 
 > You may compile the runtime with the flag `DEBUG` for debugging purposes.
-> Calls the the runtime's API will be logged as program are executed.
+> Calls to the runtime's API will be logged as programs are executed.
 
 ## Usage
 


### PR DESCRIPTION
- "The predominant safe solutions" sentence mentions only one solution. Changed to "solution".
- Separate "mutationand"
- Add a full stop after "specific installation".
- Change "LLVM is installed and configure" to "LLVM is installed and configured"
- Change "Calls the the runtime's API will be logged as program are executed." to "Calls to the runtime's API will be logged as programs are executed."